### PR TITLE
Switch to string path traverse instead of array

### DIFF
--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -21,7 +21,7 @@ for (let i = 0; i < 1000; i++) {
 
 let result = null;
 
-console.time('simple')
+console.time('simple x 10k')
 performance.mark('start-simple')
 
 for (let i = 0; i < 10_000; i++) {
@@ -29,11 +29,11 @@ for (let i = 0; i < 10_000; i++) {
 }
 
 performance.mark('end-simple')
-console.timeEnd('simple')
+console.timeEnd('simple x 10k')
 
 assert.deepEqual(result, [0])
 
-console.time('wildcard')
+console.time('wildcard x 10k')
 performance.mark('start-wildcard')
 
 for (let i = 0; i < 10_000; i++) {
@@ -41,14 +41,14 @@ for (let i = 0; i < 10_000; i++) {
 }
 
 performance.mark('end-wildcard')
-console.timeEnd('wildcard')
+console.timeEnd('wildcard x 10k')
 
 assert.equal(result[0], 'prop0.value')
 assert.equal(result[1], 'prop1.value')
 assert.equal(result[2], 'prop2.value')
 assert.equal(result[999], 'prop999.value')
 
-console.time('globstar')
+console.time('globstar x 100')
 performance.mark('start-globstar')
 
 for (let i = 0; i < 100; i++) {
@@ -56,7 +56,7 @@ for (let i = 0; i < 100; i++) {
 }
 
 performance.mark('end-globstar')
-console.timeEnd('globstar')
+console.timeEnd('globstar x 100')
 
 assert.ok(result.includes('prop0.nested0.nested1.value1'))
 assert.ok(result.includes('prop1.nested0.nested1.value1'))

--- a/src/glob.test.ts
+++ b/src/glob.test.ts
@@ -7,6 +7,9 @@ describe("globValues", () => {
     expect(globValues("c", { a: 1, b: true, c: "3", d: [1, 2], f: { a: "b" } })).toEqual(["3"]);
     expect(globValues("d", { a: 1, b: true, c: "3", d: [1, 2], f: { a: "b" } })).toEqual([[1, 2]]);
     expect(globValues("f", { a: 1, b: true, c: "3", d: [1, 2], f: { a: "b" } })).toEqual([{ a: "b" }]);
+
+    // benchmark case
+    expect(globValues("prop0.nested0.value0", { prop0: { nested0: { value0: 0 } } })).toEqual([0]);
   });
 
   it("should return matched values in an array by index", () => {


### PR DESCRIPTION
Massive perf improvement in synthetic benchmark:

Before:
```
# GitHub Actions
simple x 10k: 2.993s
wildcard x 10k: 11.394s
globstar x 100: 11.934s
```

After 🤯
```
# GitHub Actions
simple x 10k: 926.962ms
wildcard x 10k: 3.439s
globstar x 100: 2.562s
```

